### PR TITLE
make directory idempotently

### DIFF
--- a/setup-sshd
+++ b/setup-sshd
@@ -28,7 +28,7 @@
 #  docker run -e "JENKINS_SLAVE_SSH_PUBKEY=<public key>" jenkinsci/ssh-slave
 
 write_key() {
-	mkdir /home/jenkins/.ssh
+	mkdir -p /home/jenkins/.ssh
 	echo "$1" >> /home/jenkins/.ssh/authorized_keys
 	chown -Rf jenkins:jenkins /home/jenkins/.ssh
 	chmod 0700 -R /home/jenkins/.ssh
@@ -46,4 +46,3 @@ if [[ $# -gt 0 ]]; then
   fi
 fi
 exec /usr/sbin/sshd -D $@
-


### PR DESCRIPTION
Subsequent invocations of this image will no longer fail with:
``mkdir: cannot create directory ‘/home/jenkins/.ssh’: File exists``