### PR TITLE
Upgrading and shrinking the jenkinsci/ssh-slave image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+tests
+README.md
+.git
+.gitignore
+.gitattributes
+.DS_Store

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force checkout as Unix endline style
+text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM java:8-jdk
 MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
+FROM openjdk:8-jdk
 
 ENV HOME /home/jenkins
 RUN useradd -c "Jenkins user" -d $HOME -m jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         openssh-server \
     && apt-get clean
-RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+RUN sed -i 's/#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config
+RUN sed -i 's/#LogLevel.*/LogLevel INFO/' /etc/ssh/sshd_config
 RUN mkdir /var/run/sshd
 
 VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd -g ${gid} ${group} \
 # setup SSH server
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        openssh-server \
+        openssh-server git \
     && apt-get clean
 RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
 FROM openjdk:8-jdk
+LABEL MAINTAINER="Nicolas De Loof <nicolas.deloof@gmail.com>"
 
 ENV HOME /home/jenkins
 RUN useradd -c "Jenkins user" -d $HOME -m jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,6 @@ ARG uid=1000
 ARG gid=1000
 ARG JENKINS_AGENT_HOME=/home/${user}
 
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.52/remoting-2.52.jar \
-  && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/slave.jar 
 ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
 
 RUN groupadd -g ${gid} ${group} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,10 @@ RUN groupadd -g ${gid} ${group} \
     && useradd -d "${JENKINS_AGENT_HOME}" -u "${uid}" -g "${gid}" -m -s /bin/bash "${user}"
 
 # setup SSH server
-RUN apt-get update && apt-get install -y openssh-server
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        openssh-server \
+    && apt-get clean
 RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
 RUN mkdir /var/run/sshd
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,63 @@
+# The MIT License
+#
+#  Copyright (c) 2015, CloudBees, Inc.
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+FROM openjdk:8-jdk-alpine
+LABEL MAINTAINER="Nicolas De Loof <nicolas.deloof@gmail.com>"
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG JENKINS_AGENT_HOME=/home/${user}
+
+ENV JENKINS_AGENT_HOME ${JENKINS_AGENT_HOME}
+
+RUN addgroup -g ${gid} ${group} \
+    && adduser \
+        -h "${JENKINS_AGENT_HOME}" \
+        -u "${uid}" \
+        -G "${group}" \
+        -s /bin/bash \
+        -D "${user}" \
+    && echo "${user}:${user}" | chpasswd
+
+# setup SSH server
+RUN apk add --update --no-cache \
+    bash \
+    openssh
+RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config
+RUN sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+# RUN sed -i 's/#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config
+# RUN sed -i 's/#LogLevel.*/LogLevel INFO/' /etc/ssh/sshd_config
+
+RUN mkdir /var/run/sshd
+RUN rm -f /var/log/auth.log && ln -s /dev/stdout /var/log/auth.log
+
+VOLUME "${JENKINS_AGENT_HOME}" "/tmp" "/run" "/var/run"
+WORKDIR "${JENKINS_AGENT_HOME}"
+
+COPY setup-sshd /usr/local/bin/setup-sshd
+
+EXPOSE 22
+
+ENTRYPOINT ["setup-sshd"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -43,6 +43,7 @@ RUN addgroup -g ${gid} ${group} \
 # setup SSH server
 RUN apk add --update --no-cache \
     bash \
+    git \
     openssh
 RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -47,8 +47,8 @@ RUN apk add --update --no-cache \
 RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config
 RUN sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
-# RUN sed -i 's/#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config
-# RUN sed -i 's/#LogLevel.*/LogLevel INFO/' /etc/ssh/sshd_config
+RUN sed -i 's/#SyslogFacility.*/SyslogFacility AUTH/' /etc/ssh/sshd_config
+RUN sed -i 's/#LogLevel.*/LogLevel INFO/' /etc/ssh/sshd_config
 
 RUN mkdir /var/run/sshd
 RUN rm -f /var/log/auth.log && ln -s /dev/stdout /var/log/auth.log

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Dis
 
 To run a Docker container
 
-    docker run jenkinsci/ssh-slave "<public key>"
+```bash
+docker run jenkinsci/ssh-slave "<public key>"
+```
 
 You'll then be able to connect this slave using ssh-slaves-plugin as "jenkins" with the matching private key.
 
@@ -24,4 +26,3 @@ In _Environment_ field of the Docker Template (advanced section), just add:
     JENKINS_SLAVE_SSH_PUBKEY=<YOUR PUBLIC SSH KEY HERE>
 
 Don't put quotes around the public key. You should be all set.
-

--- a/setup-sshd
+++ b/setup-sshd
@@ -28,10 +28,10 @@
 #  docker run -e "JENKINS_SLAVE_SSH_PUBKEY=<public key>" jenkinsci/ssh-slave
 
 write_key() {
-	mkdir -p /home/jenkins/.ssh
-	echo "$1" > /home/jenkins/.ssh/authorized_keys
-	chown -Rf jenkins:jenkins /home/jenkins/.ssh
-	chmod 0700 -R /home/jenkins/.ssh
+	mkdir -p "${JENKINS_AGENT_HOME}/.ssh"
+	echo "$1" > "${JENKINS_AGENT_HOME}/.ssh/authorized_keys"
+	chown -Rf jenkins:jenkins "${JENKINS_AGENT_HOME}/.ssh"
+	chmod 0700 -R "${JENKINS_AGENT_HOME}/.ssh"
 }
 
 if [[ $JENKINS_SLAVE_SSH_PUBKEY == ssh-* ]]; then

--- a/setup-sshd
+++ b/setup-sshd
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 # The MIT License
 #
 #  Copyright (c) 2015, CloudBees, Inc.
@@ -45,5 +47,4 @@ if [[ $# -gt 0 ]]; then
     exec "$@"
   fi
 fi
-exec /usr/sbin/sshd -D $@
-
+exec /usr/sbin/sshd -D "${@}"

--- a/setup-sshd
+++ b/setup-sshd
@@ -47,4 +47,5 @@ if [[ $# -gt 0 ]]; then
     exec "$@"
   fi
 fi
-exec /usr/sbin/sshd -D "${@}"
+ssh-keygen -A
+exec /usr/sbin/sshd -D -e "${@}"

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -41,3 +41,29 @@ function retry {
 function get_port {
     docker port $SUT_CONTAINER $1 | cut -d: -f2
 }
+
+
+# run a given command through ssh on the test container.
+# Use the $status, $output and $lines variables to make assertions
+function run_through_ssh {
+	SSH_PORT=$(get_port 22)
+	if [ "$SSH_PORT" = "" ]; then
+		echo "failed to get SSH port"
+		false
+	else
+		TMP_PRIV_KEY_FILE=$(mktemp "$BATS_TMPDIR"/bats_private_ssh_key_XXXXXXX)
+		echo "$PRIVATE_SSH_KEY" > $TMP_PRIV_KEY_FILE \
+		 	&& chmod 0600 $TMP_PRIV_KEY_FILE
+
+		run ssh -i $TMP_PRIV_KEY_FILE \
+			-o LogLevel=quiet \
+			-o UserKnownHostsFile=/dev/null \
+			-o StrictHostKeyChecking=no \
+			-l jenkins \
+			localhost \
+			-p $SSH_PORT \
+			"$@"
+
+		rm -f $TMP_PRIV_KEY_FILE
+	fi
+}

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 # check dependencies
 (
     type docker &>/dev/null || ( echo "docker is not available"; exit 1 )
@@ -33,7 +33,7 @@ function retry {
         sleep $delay
     done
 
-    echo "Command \"$@\" failed $attempts times. Status: $status. Output: $output" 
+    echo "Command \"$@\" failed $attempts times. Status: $status. Output: $output"
     false
 }
 

--- a/tests/tests-alpine.bats
+++ b/tests/tests-alpine.bats
@@ -77,3 +77,8 @@ load keys
 			false \
 		)
 }
+
+@test "clean test container" {
+	docker kill "${SUT_CONTAINER}" &>/dev/null ||:
+	docker rm -fv "${SUT_CONTAINER}" &>/dev/null ||:
+}

--- a/tests/tests-alpine.bats
+++ b/tests/tests-alpine.bats
@@ -28,11 +28,13 @@ load keys
 	docker run -d --name "${SUT_CONTAINER}" -P $SUT_IMAGE "$PUBLIC_SSH_KEY"
 }
 
-@test "image has bash and java installed and in the PATH" {
+@test "image has bash, git and java installed and in the PATH" {
 	docker exec "${SUT_CONTAINER}" which bash
 	docker exec "${SUT_CONTAINER}" bash --version
 	docker exec "${SUT_CONTAINER}" which java
 	docker exec "${SUT_CONTAINER}" java -version
+	docker exec "${SUT_CONTAINER}" which git
+	docker exec "${SUT_CONTAINER}" git --version
 }
 
 @test "slave container is running" {

--- a/tests/tests-alpine.bats
+++ b/tests/tests-alpine.bats
@@ -12,7 +12,7 @@ load keys
 }
 
 @test "checking image metadatas" {
-	local VOLUMES_MAP="$(docker inspect -f '{{.Config.Volumes}}' jenkins-ssh-slave)"
+	local VOLUMES_MAP="$(docker inspect -f '{{.Config.Volumes}}' ${SUT_IMAGE})"
 	echo "${VOLUMES_MAP}" | grep '/tmp'
 	echo "${VOLUMES_MAP}" | grep '/home/jenkins'
 	echo "${VOLUMES_MAP}" | grep '/run'

--- a/tests/tests-alpine.bats
+++ b/tests/tests-alpine.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 
-SUT_IMAGE=jenkins-ssh-slave
-SUT_CONTAINER=bats-jenkins-ssh-slave
+SUT_IMAGE=jenkins-ssh-slave:alpine
+SUT_CONTAINER=bats-jenkins-ssh-slave-alpine
 
 load test_helpers
 load keys
 
 @test "build image" {
 	cd "$BATS_TEST_DIRNAME"/..
-	docker build -t $SUT_IMAGE .
+	docker build -t $SUT_IMAGE -f Dockerfile-alpine .
 }
 
 @test "checking image metadatas" {
@@ -50,6 +50,8 @@ load keys
 			false \
 		)
 }
+
+
 
 @test "clean test container" {
 	docker kill "${SUT_CONTAINER}" &>/dev/null ||:

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -75,3 +75,8 @@ load keys
 			false \
 		)
 }
+
+@test "clean test container" {
+	docker kill "${SUT_CONTAINER}" &>/dev/null ||:
+	docker rm -fv "${SUT_CONTAINER}" &>/dev/null ||:
+}

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -28,11 +28,13 @@ load keys
 	docker run -d --name "${SUT_CONTAINER}" -P $SUT_IMAGE "$PUBLIC_SSH_KEY"
 }
 
-@test "image has bash and java installed and in the PATH" {
+@test "image has bash, git and java installed and in the PATH" {
 	docker exec "${SUT_CONTAINER}" which bash
 	docker exec "${SUT_CONTAINER}" bash --version
 	docker exec "${SUT_CONTAINER}" which java
 	docker exec "${SUT_CONTAINER}" java -version
+	docker exec "${SUT_CONTAINER}" which git
+	docker exec "${SUT_CONTAINER}" git --version
 }
 
 @test "slave container is running" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -100,4 +100,3 @@ function run_through_ssh {
 			false \
 		)
 }
-

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -51,19 +51,6 @@ load keys
 		)
 }
 
-@test "slave.jar can be executed" {
-	run_through_ssh java -jar /usr/share/jenkins/slave.jar --help
-
-	[ "$status" = "0" ] \
-		&& [ "${lines[0]}" = '"--help" is not a valid option' ] \
-		&& [ "${lines[1]}" = 'java -jar slave.jar [options...]' ] \
-		|| (\
-			echo "status: $status"; \
-			echo "output: $output"; \
-			false \
-		)
-}
-
 # run a given command through ssh on the test container.
 # Use the $status, $output and $lines variables to make assertions
 function run_through_ssh {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -20,8 +20,8 @@ load keys
 }
 
 @test "clean test container" {
-	docker kill $SUT_CONTAINER &>/dev/null ||:
-	docker rm -fv $SUT_CONTAINER &>/dev/null ||:
+	docker kill "${SUT_CONTAINER}" &>/dev/null ||:
+	docker rm -fv "${SUT_CONTAINER}" &>/dev/null ||:
 }
 
 @test "create slave container" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -7,12 +7,12 @@ load test_helpers
 load keys
 
 @test "build image" {
-	cd "$BATS_TEST_DIRNAME"/..
-	docker build -t $SUT_IMAGE .
+	cd "${BATS_TEST_DIRNAME}"/.. || false
+	docker build -t "${SUT_IMAGE}" .
 }
 
 @test "checking image metadatas" {
-	local VOLUMES_MAP="$(docker inspect -f '{{.Config.Volumes}}' jenkins-ssh-slave)"
+	local VOLUMES_MAP="$(docker inspect -f '{{.Config.Volumes}}' ${SUT_IMAGE})"
 	echo "${VOLUMES_MAP}" | grep '/tmp'
 	echo "${VOLUMES_MAP}" | grep '/home/jenkins'
 	echo "${VOLUMES_MAP}" | grep '/run'


### PR DESCRIPTION
Hello there !

After some time using my own image which purpose is almost the same as this one, here is an update proposal that cover an upgrade to latest docker practises (1.13.0 at the time of this PR), Jenkins SSH usages, and also shrinking the image to spend less disk space.

Here are the major changes:

* Base image moved from "[java](https://hub.docker.com/_/java/)" (deprecated in 2016) to "[openjdk](https://hub.docker.com/_/openjdk/)"
* No more slave.jar (test upgraded) embeded since the Jenkins SSH agent protocol takes care of downloading and upgrading it at startup
* Ensuring that bash is the default command line (cf. https://issues.jenkins-ci.org/browse/JENKINS-41374 )
* Adapting Dockerfile instructions to use builds ARGS to allow specification of user and groups, uid and gid, following [the official Jenkins image](https://github.com/jenkinsci/docker/blob/master/Dockerfile#L8)
* SSH is now writing its logs to stderr, allowing docker logs to fetch the SSH output (and not written within a file)
* Additional data volume have been added to improve agent performances (writing temp files on host FS and not on the Layered FS)
* The default user home directory is now variabilized for better maintenance or custom build use cases
* git is now explicitly installed (tradeoff because it generally require root rights to install, so interesting to have it here, while mercurial don't)
* Some bash shellchecking
