### PR TITLE
expose environment variables to ssh session

### DIFF
--- a/setup-sshd
+++ b/setup-sshd
@@ -47,5 +47,10 @@ if [[ $# -gt 0 ]]; then
     exec "$@"
   fi
 fi
+
+
+# ensure variables passed to docker container are also exposed to ssh sessions
+env | grep _ >> /etc/environment
+
 ssh-keygen -A
 exec /usr/sbin/sshd -D -e "${@}"


### PR DESCRIPTION
as one start a ssh container, passing --env for various stuff, assumes the ssh connection will also see those variables. 
But sshd sessions do intentionally hide the parent environment, so we end with minimal set of variables from `/etc/profile`.

This workaround is inspired by comment on https://github.com/docker/docker/issues/2569#issuecomment-27973910