### PR TITLE
Clean apt cache properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd -g ${gid} ${group} \
 # setup SSH server
 RUN apt-get update \
     && apt-get install --no-install-recommends -y openssh-server \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 RUN sed -i 's/#PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
 RUN sed -i 's/#RSAAuthentication.*/RSAAuthentication yes/' /etc/ssh/sshd_config
 RUN sed -i 's/#PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config


### PR DESCRIPTION
This PR amends the package installation step to follow [Docker's best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run).