### PR TITLE
Enable Release Drafter in the repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+# Semantic versioning: https://semver.org/
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: v$NEXT_MINOR_VERSION
+name-template: v$NEXT_MINOR_VERSION


### PR DESCRIPTION
There is no versioning at the moment, so I propose to go forward with semver and the tagging format recommended by GitHub