### PR TITLE
[JENKINS-60587] - Cleanup some "slave" references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Jenkins SSH slave Docker image
+# Jenkins SSH Build Agent Docker image
 
 [`jenkins/ssh-slave`](https://hub.docker.com/r/jenkins/ssh-slave/)
 
-A [Jenkins](https://jenkins-ci.org) slave using SSH to establish connection.
+A [Jenkins](https://jenkins-ci.org) agent using SSH to establish connection.
 
 See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) for more info.
 
@@ -14,7 +14,7 @@ To run a Docker container
 docker run jenkins/ssh-slave "<public key>"
 ```
 
-You'll then be able to connect this slave using ssh-slaves-plugin as "jenkins" with the matching private key.
+You'll then be able to connect this agent using ssh-slaves-plugin as "jenkins" with the matching private key.
 
 ### How to use this image with Docker Plugin
 


### PR DESCRIPTION
This is a minor cleanup.  It will not be fuinished until https://issues.jenkins-ci.org/browse/JENKINS-59427 is implemented (name of the "SSH Slaves Plugin") and https://issues.jenkins-ci.org/browse/INFRA-1105 which renames the images themselves